### PR TITLE
Readme edits second edits - The BASE AND MASTER REVERSED AGAIN.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,38 @@ Merge the first edits into the master repository,
 them merge the master repository (now with first edits) into the second edits branch. 
 Finally I want to merge the 2nd edits into the master repository.
 
+
+Final Merge:
+
+BOTTOM LINE: ON GITHUB DOT COM, WHEN MAKING A PR (A Pull request, which could just as easily be known as a "merge request")
+
+BASE = FROM
+COMPARE = TO
+
+IT APPARENTLY IS DIFFERENT ON EVERYWHERE ELSE -- including GIT...for reasons.
+
+
+What happened was this. I merged the First-edits branch into the Master, and deleted the First-edits branch.
+
+Then I tried to merge the master (which had the new first edits) into the Second-edits branch. 
+I had set "Base" as being Second-edits and "Compare" as being the Master branch.
+It prompted me to change the master. 
+I didn't want to do that. I simply wanted the updates to master to be included in the Second-edits branch.
+
+Tried again, same prompt.
+
+Made a copy of Master Branch called Master-Copy-Two or something. 
+Tried to merge the Copy of Master-Copy-Two into Second-edits.
+Set MC2 as Compare, and 2nd edits as Base.
+It copies the changes of 2nd edits into MC2 
+
+This is the OPPOSITE of what I wanted.
+
+Made another copy of Master Branch called Master-Copy-Three.
+
+THIS TIME: Set MC3 as BASE, and 2nd edits as COMPARE.
+
+It worked, but everyone on discord said it isn't "the correct" way. Apparently blah blah blah. On Git it works differently.
+For "reasons".
+
+--Congratulations you just made it over your first hurdle in your journey to learn how to collaborate on code. Yay!

--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # hello-world-refresher
 This is a refresher on how to use github by redoing the hello-world exercise.
+
+This is a second series of edits.
+
+The idea here is to make a branch of the original hello-world-refresher repository, then create a branch of first edits. Then create a branch of second edits. Merge the first edits into the master repository, them merge the master repository (now with first edits) into the second edits branch. Finally I want to merge the 2nd edits into the master repository.
+


### PR DESCRIPTION

From @ SpaceManiac on the Codebus Discord for Space Station 13:

- when you want to merge changes from dev into master, but you don't have authority to update master, you create a PR base=master compare=dev which asks the person who does have authority to merge it
- when that won't work because of conflicts, you can use the conflict resolution web interface
- the conflict resolution web interface merges changes from base (master) into compare (dev) - you (presumably) don't have authority to update master, which is why you opened a PR at all, and the conflict resolution takes the form of a merge
- now that that merge has updated the compare (dev), the PR has no conflicts
- accepting the PR (big green button) will update base (master) with the contents of the compare (dev)
it only goes in reverse of your intuition for the "conflict resolution web interface" step
if you had a PR open with base=master compare=dev, and there were conflicts, that's what you would want to happen, due to the authorization constraints
if there are no conflicts, there is no reversal

--- This is giving me a headache. But apparently the Base and Compare swap whether they are "From" or "TO" based on whether there are changes that need resolving. *Sigh*

I am going to submit this as-is for now. This got complicated FAST.